### PR TITLE
Catch and emit client error events to prevent crashing

### DIFF
--- a/lib/xmlhttprequest.js
+++ b/lib/xmlhttprequest.js
@@ -303,6 +303,11 @@ class XMLHttpRequest extends XMLHttpRequestEventTarget {
     } else {
       client.end();
     }
+    client.on('error', err => {
+      const errorEvent = new Event('error');
+      errorEvent.error = err;
+      this.dispatchEvent(errorEvent);
+    });
   }
 
   setRequestHeader(header, value) {


### PR DESCRIPTION
Without this PR, `error` events on the request/socket, such as `ECONNRESET`, are uncaught exceptions.