### PR TITLE
Add event listener methods for EventTarget enumerability

### DIFF
--- a/lib/eventtarget.js
+++ b/lib/eventtarget.js
@@ -132,6 +132,10 @@ class EventTarget {
       throw new TypeError(
         'DOM object constructor cannot be called as a function.');
     }
+
+    this.addEventListener = this.addEventListener;
+    this.dispatchEvent = this.dispatchEvent;
+    this.removeEventListener = this.removeEventListener;
   }
 
   addEventListener(type, listener/* , capture */) {


### PR DESCRIPTION
This is needed for the following to enumerate correctly:

```
for (const k in new XMLHttpRequest()) {
  console.log(k);
}
```