### PR TITLE
Make accessors enumerable

### DIFF
--- a/lib/eventtarget.js
+++ b/lib/eventtarget.js
@@ -82,6 +82,10 @@ function _invoke(event) {
   var target = event.target;
   var type = event.type;
   var listeners = _getEventListeners.call(target, type);
+  var callbackProperty = this['on' + type];
+  if (typeof callbackProperty === 'function') {
+    listeners.unshift(callbackProperty);
+  }
   return listeners.some(function handleListener(listener) {
     if (!event.cancelable) {
       return listener.apply(target, args);

--- a/lib/xmlhttprequest.js
+++ b/lib/xmlhttprequest.js
@@ -199,6 +199,59 @@ class XMLHttpRequest extends XMLHttpRequestEventTarget {
     this.upload = null;
     this.withCredentials = false;
     this.upload = new XMLHttpRequestUpload();
+
+    this.onload = null;
+    this.onerror = null;
+    this.onprogress = null;
+    this.onloadstart = null;
+    this.onloadend = null;
+    this.onabort = null;
+
+    Object.defineProperty(this, 'responseType', {    
+      get() {
+        const responseType = this._properties.responseType;
+        if (XMLHttpRequestResponseType.indexOf(responseType) < 0) {
+          return '';
+        }
+        return responseType;
+      },
+      set(responseType) {
+        if (XMLHttpRequestResponseType.indexOf(responseType) < 0) {
+          throw new Error(''); // todo
+        }
+        this._properties.responseType = responseType;
+        return responseType;
+      },
+      enumerable: true,
+    });
+    Object.defineProperty(this, 'response', {    
+      get() {
+        switch (this.responseType) {
+          case '':
+            return this.responseText;
+          case 'arraybuffer':
+            return (new Uint8Array(Buffer.concat(this._properties.responseBuffers))).buffer;
+          case 'blob':
+            return this._properties.responseBuffers;
+          case 'document':
+            return null; // todo
+          case 'json':
+            return JSON.parse(this.responseText);
+          case 'text':
+            return this.responseText;
+          default:
+            return '';
+        }
+      },
+      enumerable: true,
+    });
+    Object.defineProperty(this, 'responseText', {    
+      get() {
+        return this._properties.responseText;
+      },
+      enumerable: true,
+    });
+
     this._properties = {
       auth: '',
       client: null,
@@ -215,48 +268,6 @@ class XMLHttpRequest extends XMLHttpRequestEventTarget {
       total: {},
       uri: '',
     };
-    this._onload = null;
-    this._onerror = null;
-    this._onprogress = null;
-  }
-
-  get responseType() {
-    const responseType = this._properties.responseType;
-    if (XMLHttpRequestResponseType.indexOf(responseType) < 0) {
-      return '';
-    }
-    return responseType;
-  }
-
-  set responseType(responseType) {
-    if (XMLHttpRequestResponseType.indexOf(responseType) < 0) {
-      throw new Error(''); // todo
-    }
-    this._properties.responseType = responseType;
-    return responseType;
-  }
-
-  get response() {
-    switch (this.responseType) {
-      case '':
-        return this.responseText;
-      case 'arraybuffer':
-        return (new Uint8Array(Buffer.concat(this._properties.responseBuffers))).buffer;
-      case 'blob':
-        return this._properties.responseBuffers;
-      case 'document':
-        return null; // todo
-      case 'json':
-        return JSON.parse(this.responseText);
-      case 'text':
-        return this.responseText;
-      default:
-        return '';
-    }
-  }
-
-  get responseText() {
-    return this._properties.responseText;
   }
 
   abort() {
@@ -341,42 +352,6 @@ class XMLHttpRequest extends XMLHttpRequestEventTarget {
       return;
     }
     this._properties.requestHeaders[header] = value;
-  }
-
-  get onload() {
-    return this._onload;
-  }
-  set onload(onload) {
-    if (this._onload) {
-      this.removeEventListener('load', this._onload);
-      this._onload = null;
-    }
-    this.addEventListener('load', onload);
-    this._onload = onload;
-  }
-
-  get onerror() {
-    return this._onerror;
-  }
-  set onerror(onerror) {
-    if (this._onerror) {
-      this.removeEventListener('error', this._onerror);
-      this._onerror = null;
-    }
-    this.addEventListener('error', onerror);
-    this._onerror = onerror;
-  }
-  
-  get onprogress() {
-    return this._onprogress;
-  }
-  set onprogress(onprogress) {
-    if (this._onprogress) {
-      this.removeEventListener('progress', this._onprogress);
-      this._onerror = null;
-    }
-    this.addEventListener('progress', onprogress);
-    this._onprogress = onprogress;
   }
 }
 


### PR DESCRIPTION
This makes `XMLHttpRequest` accessors enumerable on the instance, fixing usages that use this feature to derive a custom `XMLHttpRequest` implementation.