### PR TITLE
Return actual blobs from fetch constructor

### DIFF
--- a/lib/xmlhttprequest.js
+++ b/lib/xmlhttprequest.js
@@ -216,7 +216,9 @@ class XMLHttpRequest extends XMLHttpRequestEventTarget {
           case 'arraybuffer':
             return (new Uint8Array(Buffer.concat(this._properties.responseBuffers))).buffer;
           case 'blob':
-            return this._properties.responseBuffers;
+            return new fetch.Blob(this._properties.responseBuffers, {
+              type: this.getResponseHeader('content-type') || 'application/octet-stream',
+            });
           case 'document':
             return null; // todo
           case 'json':


### PR DESCRIPTION
We were previously returning an `Array` of the buffers.

However, since we have the proper `fetch` infrastructure imported now, we can return actual Blobs as callers expect in this case.