### PR TITLE
Do not clear response after request

### DIFF
--- a/lib/xmlhttprequest.js
+++ b/lib/xmlhttprequest.js
@@ -157,10 +157,10 @@ function _setDispatchProgressEvents(stream) {
     this.dispatchEvent(loadEvent);
     this.dispatchEvent(loadEndEvent);
 
-    setTimeout(() => {
+    /* setTimeout(() => {
       _properties.responseBuffers = null;
       _properties.responseText = '';
-    });
+    }); */
   });
 }
 


### PR DESCRIPTION
This fixes sites that use timeouts/promises after request completion and would miss the response data.

I believe this was done for memory management reasons, but it violates how browsers are expected to behave.